### PR TITLE
Fix next-image props

### DIFF
--- a/frontend/src/components/AssignmentList.tsx
+++ b/frontend/src/components/AssignmentList.tsx
@@ -108,8 +108,8 @@ export default function AssignmentList({ query }: AssignmentListProps) {
               <Image
                 src={assignment.image_url}
                 alt={assignment.title}
-                layout="fill"
-                objectFit="cover"
+                fill
+                className="object-cover"
               />
             </div>
           )}


### PR DESCRIPTION
## Summary
- update deprecated `layout`/`objectFit` props

## Testing
- `npm run build` in `frontend`
- `npm test` in `frontend` *(fails: Missing script)*
- `npm run build` in `backend`
- `npm test` in `backend` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683fccda45cc8322bd84d5e5a342423a