### PR TITLE
Fix missing use client directive in AuthContext

### DIFF
--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 
 //AuthContext.tsx
 // ユーザー認証状態を管理し、アプリケーション全体で共有するためのContextとProvider


### PR DESCRIPTION
## Summary
- add `'use client'` directive to `AuthContext.tsx`

## Testing
- `npm run lint`
- `NEXT_PUBLIC_SUPABASE_URL=http://example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68581eb234088322b46724750f4e4a05