### PR TITLE
Enhance frontend UI

### DIFF
--- a/frontend/src/app/assignments/new/page.tsx
+++ b/frontend/src/app/assignments/new/page.tsx
@@ -27,11 +27,11 @@ export default function NewAssignmentPage() {
 
   return (
     <div className="container mx-auto px-4 py-8">
-      <header className="mb-8">
-        <Link href="/" className="text-blue-500 hover:text-blue-700">
+      <header className="mb-8 bg-gradient-to-r from-blue-500 to-purple-600 text-white px-6 py-4 rounded-lg shadow flex items-center justify-between">
+        <Link href="/" className="hover:underline">
           ← 戻る
         </Link>
-        <h1 className="text-2xl font-bold mt-4">新しい課題を投稿</h1>
+        <h1 className="text-2xl font-bold">新しい課題を投稿</h1>
       </header>
 
       <main>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link'; // Next.jsのコンポーネント。クライア�
 import { useAuth } from '@/context/AuthContext'; // 認証関連のカスタムフック
 import AssignmentList from '@/components/AssignmentList'; // 課題一覧を表示するコンポーネント
 import SearchForm from '@/components/SearchForm'; // 検索フォームを表示するコンポーネント
+import Hero from '@/components/Hero';
 
 export default function HomePage() {
   const { user, isLoading, signInWithGoogle, signOut } = useAuth();
@@ -20,7 +21,7 @@ export default function HomePage() {
   // JSXを返す
   return (
     <div className="container mx-auto px-4 py-8"> {/* 全体を囲むコンテナ */}
-      <header className="flex justify-between items-center mb-10"> {/* ヘッダー */}
+      <header className="flex justify-between items-center mb-10 bg-gradient-to-r from-blue-500 to-purple-600 text-white px-6 py-4 rounded-lg shadow"> {/* ヘッダー */}
         <h1 className="text-2xl font-bold">StudyShare</h1> {/* アプリケーションのタイトル */}
         <div>
           {/* ローディング状態の表示 */}
@@ -58,6 +59,7 @@ export default function HomePage() {
       </header>
 
       <main> {/* メインコンテンツ */}
+        <Hero />
         <div className="mb-10">
           <h2 className="text-xl font-semibold mb-4">課題を検索</h2> {/* 検索セクションのタイトル */}
           <SearchForm onSearch={handleSearch} /> {/* 検索フォームコンポーネント */}

--- a/frontend/src/components/AssignmentList.tsx
+++ b/frontend/src/components/AssignmentList.tsx
@@ -104,21 +104,21 @@ export default function AssignmentList({ query }: AssignmentListProps) {
   return (
     <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
       {assignments.map((assignment) => (
-        <div key={assignment.id} className="border rounded-lg overflow-hidden shadow-sm">
+        <div key={assignment.id} className="border rounded-lg overflow-hidden shadow-sm bg-white dark:bg-gray-800 hover:shadow-lg transition-shadow group">
           {assignment.image_url && (
             <div className="w-full h-48 overflow-hidden relative">
               <Image
                 src={assignment.image_url}
                 alt={assignment.title}
                 fill
-                className="object-cover"
+                className="object-cover group-hover:scale-105 transition-transform"
               />
             </div>
           )}
           <div className="p-4">
             <h3 className="text-xl font-semibold">{assignment.title}</h3>
-            <p className="text-gray-600 mt-2">{assignment.description}</p>
-            <div className="flex justify-between items-center mt-4 text-sm text-gray-500">
+            <p className="text-gray-600 dark:text-gray-300 mt-2">{assignment.description}</p>
+            <div className="flex justify-between items-center mt-4 text-sm text-gray-500 dark:text-gray-400">
               <span>投稿者: {assignment.user?.email || '不明'}</span>
               <span>{new Date(assignment.created_at).toLocaleString('ja-JP')}</span>
             </div>
@@ -127,7 +127,7 @@ export default function AssignmentList({ query }: AssignmentListProps) {
             {isAdmin && (
               <button
                 onClick={() => handleDelete(assignment.id)}
-                className="mt-3 px-3 py-1 text-sm text-red-600 border border-red-600 rounded hover:bg-red-50"
+                className="mt-3 px-3 py-1 text-sm text-red-600 border border-red-600 rounded hover:bg-red-50 dark:hover:bg-red-900"
               >
                 削除
               </button>

--- a/frontend/src/components/Hero.tsx
+++ b/frontend/src/components/Hero.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link';
+import { useAuth } from '@/context/AuthContext';
+
+export default function Hero() {
+  const { user, signInWithGoogle } = useAuth();
+  return (
+    <section className="bg-gradient-to-r from-blue-500 to-purple-600 text-white py-20 rounded-lg shadow-lg mb-12">
+      <div className="container mx-auto px-4 text-center">
+        <h2 className="text-4xl font-bold mb-4">課題を共有して学びを深めよう</h2>
+        <p className="mb-8 text-lg">StudyShareは大学の課題をみんなで共有し合うためのプラットフォームです。</p>
+        {user ? (
+          <Link href="/assignments/new" className="bg-white/20 hover:bg-white/30 px-6 py-3 rounded-md">
+            課題を投稿
+          </Link>
+        ) : (
+          <button onClick={() => signInWithGoogle()} className="bg-white/20 hover:bg-white/30 px-6 py-3 rounded-md">
+            Googleでログイン
+          </button>
+        )}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add Hero section for improved landing page
- style headers with gradients
- tweak assignment list card styles

## Testing
- `npx next lint`
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_685ca08320c48322994bc980a5d6064d