### PR TITLE
Add backend request validation

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,7 +14,8 @@
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "jose": "^6.0.10",
-        "multer": "^1.4.5-lts.2"
+        "multer": "^1.4.5-lts.2",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
@@ -2040,6 +2041,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
-    "seed": "ts-node src/scripts/seed.ts", 
+    "seed": "ts-node src/scripts/seed.ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
@@ -19,7 +19,8 @@
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "jose": "^6.0.10",
-    "multer": "^1.4.5-lts.2"
+    "multer": "^1.4.5-lts.2",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/backend/src/middleware/validate.ts
+++ b/backend/src/middleware/validate.ts
@@ -1,0 +1,21 @@
+import { AnyZodObject, ZodError } from 'zod';
+import { Request, Response, NextFunction } from 'express';
+
+const validate = (schema: AnyZodObject) => (req: Request, res: Response, next: NextFunction): void => {
+  try {
+    schema.parse({
+      body: req.body,
+      query: req.query,
+      params: req.params,
+    });
+    next();
+  } catch (error) {
+    if (error instanceof ZodError) {
+      res.status(400).json({ errors: error.issues });
+      return;
+    }
+    next(error);
+  }
+};
+
+export default validate;

--- a/backend/src/routes/assignments.ts
+++ b/backend/src/routes/assignments.ts
@@ -4,6 +4,8 @@ import { Router } from 'express';
 import multer from 'multer';
 import supabase from '../lib/supabase';
 import { authenticate, requireAdmin } from '../middleware/auth'; // 作成したミドルウェア
+import validate from '../middleware/validate';
+import { createAssignmentSchema } from '../validators/assignment';
 
 const router = Router();
 
@@ -64,15 +66,10 @@ router.post('/upload', authenticate, upload.single('image'), async (req, res) =>
  * 課題投稿 API
  * POST /api/assignments
  */
-router.post('/assignments', authenticate, async (req, res) => {
+router.post('/assignments', authenticate, validate(createAssignmentSchema), async (req, res) => {
   const { title, description, image_url } = req.body;
   // @ts-ignore
   const userId = req.user.id;
-
-  if (!title || !description) {
-    res.status(400).json({ message: 'タイトルと説明は必須です。' });
-    return;
-  }
 
   try {
     const { data, error } = await supabase

--- a/backend/src/validators/assignment.ts
+++ b/backend/src/validators/assignment.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const createAssignmentSchema = z.object({
+  body: z.object({
+    title: z.string().min(1, 'タイトルは必須です'),
+    description: z.string().min(1, '説明は必須です'),
+    image_url: z.string().url('正しいURLではありません').optional(),
+  }),
+});


### PR DESCRIPTION
## Summary
- validate request bodies with zod
- add schema for assignment creation and apply to route

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a04114ca548322831df56c8b2b6924