### PR TITLE
Use real timetable data on home page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ## AGENTS.md (Project Guide for `studyshare`)
 
-最終更新: 2026-03-15
+最終更新: 2026-03-19
 
 このファイルは、`studyshare` の現状実装に合わせた作業ガイドです。  
 古い「課題共有アプリ」前提だけで判断しないこと。現在は `授業/口コミ + ノート + 時間割 + コミュニティ` を中心にした大学生活アプリへ移行済みです。
@@ -10,7 +10,7 @@
 
 ### 現行の主機能（本体導線）
 - ランディング + Googleログイン (`/`)
-- ホーム (`/home`) ※現在は `homeMockData` ベース
+- ホーム (`/home`) ※時間割カードは実データ、その他は `homeMockData` ベース
 - 授業・口コミ一覧 (`/offerings`)
 - 授業詳細 (`/offerings/[offeringId]`) でノート/口コミ/質問/受講者数
 - ノート詳細 (`/offerings/[offeringId]/notes/[noteId]`) でコメント/返信（無制限ツリー）
@@ -165,7 +165,9 @@ bucket未作成時:
 - 質問詳細ページで回答/返信投稿（`question_answers.parent_answer_id`）
 
 ### 現在のプレースホルダ / 暫定仕様（作業時に誤解しやすい）
-- `/home` は `homeMockData` 使用（実データ化未完）
+- `/home`:
+  - 「今週の時間割」カードは実データ（`list_my_timetable` + `profile_timetable_settings` / `timetable_presets`）を表示
+  - 口コミ / 最近見た授業 / 人気の授業 / ミニ掲示板は `homeMockData` 使用（実データ化未完）
 - `community`:
   - `reviews` / `more` タブは準備中
   - チップフィルタUIはあるが、取得クエリ条件に未反映（`activeChip` stateのみ）

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -14,6 +14,8 @@
 - `AssignmentList` 検索/一覧表示
 - `AuthContext` 認証状態の更新
 - `AppRouteGuard` の未ログイン時リダイレクト / 初期設定未完了時 `onboarding` リダイレクト / 完了時通過
+- `home/page` の主要セクション表示と `HomeTimetableSection` 差し込み
+- `WeeklyTimetable` の実データ表示（ユーザー設定依存の曜日/時限、重複 `+N`、空状態、エラー、設定外/時間未設定件数）
 - `TimetableGrid` ローディング/空状態/表示切替（`dropped`トグル）/設定依存の行列描画/設定外授業警告/セル遷移/戻りハイライト/削除/再登録/重複モーダル同期
 - `TimetableCell` セル表示（授業カード/空セル）と遷移動作、削除/再登録アクション
 - `TimetableAddPage` の文脈ヘッダー/検索語初期値/学期切替/slot match 優先表示
@@ -108,6 +110,8 @@
 - 設定パネルの公開範囲保存で連打しても RPC が二重発火しない
 - `/timetable` から「時間・曜日を変更」で `/me?modal=timetable-settings&from=timetable` に遷移できる
 - 時間割設定を変更した内容が `/timetable` の行列（曜日・時限）に反映される
+- ホーム (`/home`) の「今週の時間割」が `/timetable` と同じ現在学期・曜日・時限設定で表示される
+- ホーム (`/home`) で設定外/時間未設定の授業件数が表示され、`/timetable` 導線から詳細確認できる
 - `5限` / `6限` / `7限` / `10限` の大学を切り替えたとき、`/onboarding`・`/me`・`/timetable`・`/timetable/add` が同じ時限数で揃う
 - `/timetable?termId=...` で表示 term が切り替わり、別 term に切り替えても過去 term の履修が消えない
 - 設定外スロットの授業がある場合に警告表示される

--- a/frontend/src/app/(app)/home/page.test.tsx
+++ b/frontend/src/app/(app)/home/page.test.tsx
@@ -2,10 +2,16 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import HomePage from './page';
 
+jest.mock('@/components/home/HomeTimetableSection', () => ({
+  __esModule: true,
+  default: () => <div data-testid="home-timetable-section">今週の時間割</div>,
+}));
+
 describe('HomePage', () => {
   it('renders all primary dashboard sections', () => {
     render(<HomePage />);
 
+    expect(screen.getByTestId('home-timetable-section')).toBeInTheDocument();
     expect(screen.getByText('今週の時間割')).toBeInTheDocument();
     expect(screen.getByText('新着の口コミ')).toBeInTheDocument();
     expect(screen.getByText('最近見た授業')).toBeInTheDocument();

--- a/frontend/src/app/(app)/home/page.tsx
+++ b/frontend/src/app/(app)/home/page.tsx
@@ -1,13 +1,12 @@
 import HotPosts, { MiniBoard } from '@/components/home/HotPosts';
+import HomeTimetableSection from '@/components/home/HomeTimetableSection';
 import NewReviews from '@/components/home/NewReviews';
 import PopularCourses from '@/components/home/PopularCourses';
 import RecentlyViewedCourses from '@/components/home/RecentlyViewedCourses';
-import WeeklyTimetable from '@/components/home/WeeklyTimetable';
 import { homeMockData } from '@/lib/mock/homeMock';
 
 export default function HomePage() {
   const courses = Array.isArray(homeMockData.courses) ? homeMockData.courses : [];
-  const timetableItems = Array.isArray(homeMockData.timetableItems) ? homeMockData.timetableItems : [];
   const reviews = Array.isArray(homeMockData.reviews) ? homeMockData.reviews : [];
   const hotPosts = Array.isArray(homeMockData.hotPosts) ? homeMockData.hotPosts : [];
   const miniBoardPosts = Array.isArray(homeMockData.miniBoardPosts) ? homeMockData.miniBoardPosts : [];
@@ -27,7 +26,7 @@ export default function HomePage() {
   return (
     <div className="mx-auto w-full max-w-7xl space-y-6">
       <div className="grid gap-6 xl:grid-cols-[minmax(0,2fr)_minmax(320px,1fr)]">
-        <WeeklyTimetable courses={courses} timetableItems={timetableItems} />
+        <HomeTimetableSection />
         <NewReviews reviews={reviews} />
       </div>
 

--- a/frontend/src/components/home/HomeTimetableSection.test.tsx
+++ b/frontend/src/components/home/HomeTimetableSection.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react';
+import { useTimetableGridData } from '@/components/timetable/useTimetableGridData';
+import { createSupabaseClient } from '@/lib/supabase/client';
+import HomeTimetableSection from './HomeTimetableSection';
+
+jest.mock('@/lib/supabase/client', () => ({
+  createSupabaseClient: jest.fn(),
+}));
+
+jest.mock('@/components/timetable/useTimetableGridData', () => ({
+  useTimetableGridData: jest.fn(),
+}));
+
+const createSupabaseClientMock = createSupabaseClient as jest.Mock;
+const useTimetableGridDataMock = useTimetableGridData as jest.Mock;
+
+describe('HomeTimetableSection', () => {
+  const supabaseClient = { auth: {}, from: jest.fn(), rpc: jest.fn() };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    createSupabaseClientMock.mockReturnValue(supabaseClient);
+    useTimetableGridDataMock.mockReturnValue({
+      enrollmentEntries: [],
+      terms: [
+        {
+          id: 'term-1',
+          academicYear: 2026,
+          code: 'first_half',
+          displayName: '前期',
+          sortKey: 10,
+          startDate: '2026-04-01',
+          endDate: '2026-08-01',
+        },
+      ],
+      timetableConfig: {
+        weekdays: [1, 2, 3, 4, 5],
+        periods: [{ period: 1, label: '1限', startTime: '09:00', endTime: '10:40' }],
+      },
+      isLoading: false,
+      errorMessage: null,
+      resolvedTermId: 'term-1',
+      updateEnrollmentStatusLocally: jest.fn(),
+    });
+  });
+
+  it('uses timetable grid data with the home-specific defaults', () => {
+    render(<HomeTimetableSection />);
+
+    expect(useTimetableGridDataMock).toHaveBeenCalledWith({
+      rawSelectedTermId: null,
+      showDropped: false,
+      supabase: supabaseClient,
+    });
+  });
+
+  it('renders the resolved term label through WeeklyTimetable', () => {
+    render(<HomeTimetableSection />);
+
+    expect(screen.getByText('表示中: 2026 前期')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '時間割を見る' })).toHaveAttribute('href', '/timetable');
+  });
+
+  it('renders the hook error state inside the timetable card', () => {
+    useTimetableGridDataMock.mockReturnValue({
+      enrollmentEntries: [],
+      terms: [],
+      timetableConfig: {
+        weekdays: [1, 2, 3, 4, 5],
+        periods: [{ period: 1, label: '1限', startTime: '09:00', endTime: '10:40' }],
+      },
+      isLoading: false,
+      errorMessage: '時間割の取得に失敗しました。しばらくしてから再度お試しください。',
+      resolvedTermId: null,
+      updateEnrollmentStatusLocally: jest.fn(),
+    });
+
+    render(<HomeTimetableSection />);
+
+    expect(screen.getByText('時間割の取得に失敗しました。しばらくしてから再度お試しください。')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/home/HomeTimetableSection.tsx
+++ b/frontend/src/components/home/HomeTimetableSection.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useMemo } from 'react';
+import WeeklyTimetable from '@/components/home/WeeklyTimetable';
+import { useTimetableGridData } from '@/components/timetable/useTimetableGridData';
+import { createSupabaseClient } from '@/lib/supabase/client';
+import { buildTermLabel } from '@/lib/timetable/terms';
+
+export default function HomeTimetableSection() {
+  const supabase = useMemo(() => createSupabaseClient(), []);
+  const {
+    enrollmentEntries,
+    terms,
+    timetableConfig,
+    isLoading,
+    errorMessage,
+    resolvedTermId,
+  } = useTimetableGridData({
+    rawSelectedTermId: null,
+    showDropped: false,
+    supabase,
+  });
+
+  const resolvedTerm = terms.find((term) => term.id === resolvedTermId) ?? null;
+
+  return (
+    <WeeklyTimetable
+      timetableConfig={timetableConfig}
+      enrollmentEntries={enrollmentEntries}
+      termLabel={resolvedTerm ? buildTermLabel(resolvedTerm) : null}
+      isLoading={isLoading}
+      errorMessage={errorMessage}
+    />
+  );
+}

--- a/frontend/src/components/home/WeeklyTimetable.test.tsx
+++ b/frontend/src/components/home/WeeklyTimetable.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen } from '@testing-library/react';
+import WeeklyTimetable from './WeeklyTimetable';
+
+describe('WeeklyTimetable', () => {
+  const timetableConfig = {
+    weekdays: [1, 2, 5] as const,
+    periods: [
+      { period: 1, label: '1限', startTime: '09:00', endTime: '10:40' },
+      { period: 3, label: '3限', startTime: '13:10', endTime: '14:50' },
+    ],
+  };
+
+  it('renders configured slots, overlap badges, and hidden-offering summary', () => {
+    render(
+      <WeeklyTimetable
+        timetableConfig={timetableConfig}
+        termLabel="2026 前期"
+        isLoading={false}
+        errorMessage={null}
+        enrollmentEntries={[
+          {
+            offeringId: 'offering-1',
+            termId: 'term-1',
+            courseTitle: 'Webプログラミング',
+            instructorName: '田中 健太',
+            colorToken: 'sky',
+            createdAt: '2026-03-01T09:00:00.000Z',
+            status: 'enrolled',
+            slots: [{ dayOfWeek: 1, period: 1, startTime: '09:00' }],
+            isUnslotted: false,
+            room: null,
+          },
+          {
+            offeringId: 'offering-2',
+            termId: 'term-1',
+            courseTitle: '線形代数学',
+            instructorName: '佐藤 一郎',
+            colorToken: 'amber',
+            createdAt: '2026-03-02T09:00:00.000Z',
+            status: 'planned',
+            slots: [{ dayOfWeek: 1, period: 1, startTime: '09:00' }],
+            isUnslotted: false,
+            room: null,
+          },
+          {
+            offeringId: 'offering-3',
+            termId: 'term-1',
+            courseTitle: '統計学',
+            instructorName: '伊藤 花',
+            colorToken: 'rose',
+            createdAt: '2026-03-03T09:00:00.000Z',
+            status: 'enrolled',
+            slots: [{ dayOfWeek: 6, period: 1, startTime: '09:00' }],
+            isUnslotted: false,
+            room: null,
+          },
+          {
+            offeringId: 'offering-4',
+            termId: 'term-1',
+            courseTitle: '経営学',
+            instructorName: '高橋 陽',
+            colorToken: 'teal',
+            createdAt: '2026-03-04T09:00:00.000Z',
+            status: 'enrolled',
+            slots: [],
+            isUnslotted: true,
+            room: null,
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('表示中: 2026 前期')).toBeInTheDocument();
+    expect(screen.getByText('月')).toBeInTheDocument();
+    expect(screen.getByText('火')).toBeInTheDocument();
+    expect(screen.getByText('金')).toBeInTheDocument();
+    expect(screen.getByText('1限')).toBeInTheDocument();
+    expect(screen.getByText('3限')).toBeInTheDocument();
+    expect(screen.getByText('Webプログラミング')).toBeInTheDocument();
+    expect(screen.getByText('田中 健太')).toBeInTheDocument();
+    expect(screen.getByText('09:00 - 10:40')).toBeInTheDocument();
+    expect(screen.getByText('+1')).toBeInTheDocument();
+    expect(screen.getByText('時間未設定/設定外の授業 2 件')).toBeInTheDocument();
+  });
+
+  it('shows loading state while the timetable is being fetched', () => {
+    render(
+      <WeeklyTimetable
+        timetableConfig={timetableConfig}
+        termLabel={null}
+        isLoading
+        errorMessage={null}
+        enrollmentEntries={[]}
+      />,
+    );
+
+    expect(screen.getByText('時間割を読み込み中...')).toBeInTheDocument();
+  });
+
+  it('shows error state without breaking the card layout', () => {
+    render(
+      <WeeklyTimetable
+        timetableConfig={timetableConfig}
+        termLabel="2026 前期"
+        isLoading={false}
+        errorMessage="時間割の取得に失敗しました。しばらくしてから再度お試しください。"
+        enrollmentEntries={[]}
+      />,
+    );
+
+    expect(screen.getByText('時間割の取得に失敗しました。しばらくしてから再度お試しください。')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '時間割を見る' })).toHaveAttribute('href', '/timetable');
+  });
+
+  it('shows empty state and CTA when there are no visible classes', () => {
+    render(
+      <WeeklyTimetable
+        timetableConfig={timetableConfig}
+        termLabel="2026 前期"
+        isLoading={false}
+        errorMessage={null}
+        enrollmentEntries={[]}
+      />,
+    );
+
+    expect(screen.getByText('表示中の学期に、ホームで表示できる授業はまだありません。')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '時間割で確認する' })).toHaveAttribute('href', '/timetable');
+  });
+});

--- a/frontend/src/components/home/WeeklyTimetable.tsx
+++ b/frontend/src/components/home/WeeklyTimetable.tsx
@@ -1,90 +1,234 @@
+import Link from 'next/link';
+import type { TimetableEnrollmentEntry } from '@/components/timetable/useTimetableGridData';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
-import type { Course, TimetableDay, TimetableItem } from '@/lib/mock/homeMock';
+import { formatWeekdayLabel } from '@/lib/timetable/config';
+import type { TimetableColorToken, TimetableConfig, TimetableStatus } from '@/types/timetable';
 
 export type WeeklyTimetableProps = {
-  courses: Course[];
-  timetableItems: TimetableItem[];
+  timetableConfig: TimetableConfig;
+  enrollmentEntries: TimetableEnrollmentEntry[];
+  termLabel: string | null;
+  isLoading: boolean;
+  errorMessage: string | null;
 };
 
-const days: TimetableDay[] = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
-
-const dayLabels: Record<TimetableDay, string> = {
-  Mon: '月',
-  Tue: '火',
-  Wed: '水',
-  Thu: '木',
-  Fri: '金',
+type HomeTimetableCellItem = {
+  offeringId: string;
+  courseTitle: string;
+  instructorName: string;
+  startTime: string;
+  endTime: string;
+  colorToken: TimetableColorToken;
+  status: TimetableStatus;
+  createdAt: string;
 };
 
-const timeSlots = ['9:00', '10:45', '13:10', '14:55'];
+const STATUS_PRIORITY: Record<TimetableStatus, number> = {
+  enrolled: 0,
+  planned: 1,
+  dropped: 2,
+};
 
-const colorStyles: Record<TimetableItem['colorToken'], string> = {
-  blue: 'border-blue-200 bg-blue-50 text-blue-900',
+const colorStyles: Record<TimetableColorToken, string> = {
+  sky: 'border-sky-200 bg-sky-50 text-sky-900',
   indigo: 'border-indigo-200 bg-indigo-50 text-indigo-900',
   emerald: 'border-emerald-200 bg-emerald-50 text-emerald-900',
   amber: 'border-amber-200 bg-amber-50 text-amber-900',
   rose: 'border-rose-200 bg-rose-50 text-rose-900',
+  teal: 'border-teal-200 bg-teal-50 text-teal-900',
 };
 
-export default function WeeklyTimetable({ courses, timetableItems }: WeeklyTimetableProps) {
-  const courseMap = new Map(courses.map((course) => [course.id, course]));
+function buildCellKey(dayOfWeek: number, period: number) {
+  return `${dayOfWeek}-${period}`;
+}
+
+function resolveHiddenOfferingCount(entries: TimetableEnrollmentEntry[], config: TimetableConfig) {
+  const visibleDaySet = new Set(config.weekdays);
+  const visiblePeriodSet = new Set(config.periods.map((period) => period.period));
+  const hiddenOfferingIds = new Set<string>();
+
+  entries.forEach((entry) => {
+    if (entry.isUnslotted) {
+      hiddenOfferingIds.add(entry.offeringId);
+      return;
+    }
+
+    const hasOutOfConfigSlot = entry.slots.some(
+      (slot) => !visibleDaySet.has(slot.dayOfWeek) || !visiblePeriodSet.has(slot.period),
+    );
+
+    if (hasOutOfConfigSlot) {
+      hiddenOfferingIds.add(entry.offeringId);
+    }
+  });
+
+  return hiddenOfferingIds.size;
+}
+
+function buildVisibleCellMap(entries: TimetableEnrollmentEntry[], config: TimetableConfig) {
+  const visibleDaySet = new Set(config.weekdays);
+  const visiblePeriodSet = new Set(config.periods.map((period) => period.period));
+  const cellMap = new Map<string, HomeTimetableCellItem[]>();
+
+  entries.forEach((entry) => {
+    entry.slots.forEach((slot) => {
+      if (!visibleDaySet.has(slot.dayOfWeek) || !visiblePeriodSet.has(slot.period)) {
+        return;
+      }
+
+      const periodConfig = config.periods.find((period) => period.period === slot.period);
+      if (!periodConfig) {
+        return;
+      }
+
+      const key = buildCellKey(slot.dayOfWeek, slot.period);
+      const items = cellMap.get(key) ?? [];
+      items.push({
+        offeringId: entry.offeringId,
+        courseTitle: entry.courseTitle,
+        instructorName: entry.instructorName,
+        startTime: slot.startTime,
+        endTime: periodConfig.endTime,
+        colorToken: entry.colorToken,
+        status: entry.status,
+        createdAt: entry.createdAt,
+      });
+      cellMap.set(key, items);
+    });
+  });
+
+  cellMap.forEach((items) => {
+    items.sort((left, right) => {
+      const statusDiff = STATUS_PRIORITY[left.status] - STATUS_PRIORITY[right.status];
+      if (statusDiff !== 0) {
+        return statusDiff;
+      }
+
+      return left.createdAt.localeCompare(right.createdAt);
+    });
+  });
+
+  return cellMap;
+}
+
+export default function WeeklyTimetable({
+  timetableConfig,
+  enrollmentEntries,
+  termLabel,
+  isLoading,
+  errorMessage,
+}: WeeklyTimetableProps) {
+  const cellMap = buildVisibleCellMap(enrollmentEntries, timetableConfig);
+  const hiddenOfferingCount = resolveHiddenOfferingCount(enrollmentEntries, timetableConfig);
+  const hasVisibleEntries = Array.from(cellMap.values()).some((items) => items.length > 0);
+  const emptyMessage = termLabel
+    ? '表示中の学期に、ホームで表示できる授業はまだありません。'
+    : '表示できる学期がまだありません。';
 
   return (
     <Card>
-      <CardHeader>
-        <CardTitle>今週の時間割</CardTitle>
+      <CardHeader className="flex-wrap gap-3">
+        <div>
+          <CardTitle>今週の時間割</CardTitle>
+          <p className="mt-1 text-sm text-slate-500">{termLabel ? `表示中: ${termLabel}` : '表示中の学期: 未設定'}</p>
+        </div>
+        <Link
+          href="/timetable"
+          className="inline-flex items-center rounded-full bg-blue-500 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-400"
+        >
+          時間割を見る
+        </Link>
       </CardHeader>
 
       <CardContent>
-        <div className="overflow-x-auto">
-          <table className="w-full min-w-[680px] table-fixed border-separate border-spacing-0 text-sm">
-            <thead>
-              <tr>
-                <th className="w-20 border-b border-slate-200 px-2 py-2 text-left font-semibold text-slate-500" />
-                {days.map((day) => (
-                  <th
-                    key={day}
-                    className="border-b border-slate-200 px-2 py-2 text-center font-semibold text-slate-600"
-                  >
-                    {dayLabels[day]}
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {timeSlots.map((slot) => (
-                <tr key={slot}>
-                  <td className="border-b border-slate-100 px-2 py-3 align-top text-slate-500">{slot}</td>
-                  {days.map((day) => {
-                    const item = timetableItems.find((entry) => entry.day === day && entry.start === slot);
-                    const course = item ? courseMap.get(item.courseId) : null;
-
-                    return (
-                      <td key={`${day}-${slot}`} className="h-28 border-b border-slate-100 px-2 py-2 align-top">
-                        {item && course ? (
-                          <div
-                            className={[
-                              'rounded-xl border p-2.5 shadow-sm',
-                              colorStyles[item.colorToken],
-                            ].join(' ')}
-                          >
-                            <p className="line-clamp-1 text-sm font-semibold">{course.title}</p>
-                            <p className="mt-1 text-xs">{course.professor}</p>
-                            <p className="mt-1 text-xs opacity-80">
-                              {item.start} - {item.end}
-                            </p>
-                          </div>
-                        ) : (
-                          <div className="h-full rounded-xl border border-dashed border-slate-200 bg-slate-50/60" />
-                        )}
-                      </td>
-                    );
-                  })}
+        {isLoading ? (
+          <div className="space-y-4">
+            <p className="text-sm text-slate-500">時間割を読み込み中...</p>
+            <div className="grid gap-3 sm:grid-cols-3">
+              <div className="h-24 rounded-2xl bg-slate-100" />
+              <div className="h-24 rounded-2xl bg-slate-100" />
+              <div className="h-24 rounded-2xl bg-slate-100" />
+            </div>
+          </div>
+        ) : errorMessage ? (
+          <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-5 text-sm text-rose-700">
+            {errorMessage}
+          </div>
+        ) : !hasVisibleEntries ? (
+          <div className="rounded-2xl border border-dashed border-slate-300 bg-slate-50 px-4 py-8 text-center">
+            <p className="text-sm text-slate-600">{emptyMessage}</p>
+            <Link
+              href="/timetable"
+              className="mt-4 inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-100"
+            >
+              時間割で確認する
+            </Link>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[680px] table-fixed border-separate border-spacing-0 text-sm">
+              <thead>
+                <tr>
+                  <th className="w-24 border-b border-slate-200 px-2 py-2 text-left font-semibold text-slate-500" />
+                  {timetableConfig.weekdays.map((day) => (
+                    <th
+                      key={day}
+                      className="border-b border-slate-200 px-2 py-2 text-center font-semibold text-slate-600"
+                    >
+                      {formatWeekdayLabel(day)}
+                    </th>
+                  ))}
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody>
+                {timetableConfig.periods.map((period) => (
+                  <tr key={period.period}>
+                    <td className="border-b border-slate-100 px-2 py-3 align-top text-slate-500">
+                      <p className="font-medium text-slate-700">{period.label}</p>
+                      <p className="mt-1 text-xs">{period.startTime}</p>
+                    </td>
+                    {timetableConfig.weekdays.map((day) => {
+                      const items = cellMap.get(buildCellKey(day, period.period)) ?? [];
+                      const primaryItem = items[0] ?? null;
+
+                      return (
+                        <td key={`${day}-${period.period}`} className="h-28 border-b border-slate-100 px-2 py-2 align-top">
+                          {primaryItem ? (
+                            <div className={['rounded-xl border p-2.5 shadow-sm', colorStyles[primaryItem.colorToken]].join(' ')}>
+                              <div className="flex items-start justify-between gap-2">
+                                <p className="line-clamp-2 text-sm font-semibold">{primaryItem.courseTitle}</p>
+                                {items.length > 1 ? (
+                                  <span className="rounded-full bg-white/80 px-2 py-0.5 text-[11px] font-semibold">
+                                    +{items.length - 1}
+                                  </span>
+                                ) : null}
+                              </div>
+                              <p className="mt-1 line-clamp-1 text-xs">{primaryItem.instructorName}</p>
+                              <p className="mt-1 text-xs opacity-80">
+                                {primaryItem.startTime} - {primaryItem.endTime}
+                              </p>
+                            </div>
+                          ) : (
+                            <div className="h-full rounded-xl border border-dashed border-slate-200 bg-slate-50/60" />
+                          )}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {!isLoading && hiddenOfferingCount > 0 ? (
+          <div className="mt-4 flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
+            <p className="text-sm text-slate-600">時間未設定/設定外の授業 {hiddenOfferingCount} 件</p>
+            <Link href="/timetable" className="text-sm font-semibold text-blue-600 hover:text-blue-500">
+              時間割で確認
+            </Link>
+          </div>
+        ) : null}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
Replace mocked input for WeeklyTimetable in page.tsx with real data from HomeTimetableSection.tsx Reuse useTimetableGridData({ rawSelectedTermId: null, showDropped: false }) to pass current term timetable and university‑specific day/period settings to the home page